### PR TITLE
Use the new url scheme and drop latest

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -12,4 +12,4 @@ addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")
 
 addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.5.5")
 addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.1.16")
-addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.5.0")
+addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.5.1")

--- a/sbt-locales/src/main/scala/locales/IOTasks.scala
+++ b/sbt-locales/src/main/scala/locales/IOTasks.scala
@@ -18,7 +18,7 @@ object IOTasks {
     val zipFile    = localesDir / coreZip.getName
     if (!zipFile.exists) {
       val url =
-        s"http://unicode.org/Public/cldr/${cldrVersion.id}/core.zip"
+        s"http://unicode.org/Public/cldr/${cldrVersion.dir}/cldr-common-${cldrVersion.id}.zip"
       for {
         _ <-
           IO(

--- a/sbt-locales/src/main/scala/locales/LocalesPlugin.scala
+++ b/sbt-locales/src/main/scala/locales/LocalesPlugin.scala
@@ -29,7 +29,7 @@ object LocalesPlugin extends AutoPlugin {
         localesCodeGen := Def.task {
           val cacheLocation                                  = streams.value.cacheDirectory / s"cldr-locales"
           val log                                            = streams.value.log
-          val coreZip                                        = cacheLocation / s"core-${cldrVersion.value.id}.zip"
+          val coreZip                                        = cacheLocation / s"core-${cldrVersion.value}.zip"
           val cachedActionFunction: Set[JFile] => Set[JFile] =
             FileFunction.cached(
               cacheLocation,
@@ -71,7 +71,7 @@ object LocalesPlugin extends AutoPlugin {
     supportDateTimeFormats := true,
     supportNumberFormats := false,
     supportISOCodes := false,
-    cldrVersion := CLDRVersion.LatestVersion
+    cldrVersion := CLDRVersion.Version("38.1")
   )
   // a group of settings that are automatically added to projects.
   override val projectSettings    =

--- a/sbt-locales/src/main/scala/locales/package.scala
+++ b/sbt-locales/src/main/scala/locales/package.scala
@@ -4,14 +4,16 @@ import cats.syntax.all._
 
 sealed trait CLDRVersion extends Product with Serializable {
   def id: String
+  def dir: String
 }
 
 object CLDRVersion {
-  case object LatestVersion extends CLDRVersion {
-    val id: String = "latest"
-  }
   final case class Version(version: String) extends CLDRVersion {
-    val id: String = version
+    val id: String  = version
+    val dir: String = version.split('.').toList match {
+      case List(v, "0") => v
+      case _            => version
+    }
   }
 }
 

--- a/sbt-locales/src/sbt-test/sbt-locales/common-filtering/build.sbt
+++ b/sbt-locales/src/sbt-test/sbt-locales/common-filtering/build.sbt
@@ -7,11 +7,12 @@ lazy val root =
     .in(file("."))
     .settings(
       name := "no-filtering",
-      scalaVersion := "2.13.4",
+      cldrVersion := CLDRVersion.Version("38.1"),
+      scalaVersion := "3.0.0-M2",
       localesFilter := LocalesFilter.Selection("en-US", "fi", "fi-FI"),
       nsFilter := NumberingSystemFilter.Minimal,
       currencyFilter := CurrencyFilter.Selection("EUR"),
       supportISOCodes := true,
       supportNumberFormats := true,
-      libraryDependencies += "org.portable-scala" %%% "portable-scala-reflect" % "1.0.0"
+      libraryDependencies += ("org.portable-scala" %%% "portable-scala-reflect" % "1.0.0").withDottyCompat(scalaVersion.value)
     )

--- a/sbt-locales/src/sbt-test/sbt-locales/common-filtering/project/plugins.sbt
+++ b/sbt-locales/src/sbt-test/sbt-locales/common-filtering/project/plugins.sbt
@@ -3,5 +3,6 @@ addSbtPlugin(
     .getOrElse("plugin.version", sys.error("'plugin.version' environment variable is not set"))
 )
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.0.0")
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.1.0")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.3.1")
 addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.1.16")
+addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.5.1")

--- a/sbt-locales/src/sbt-test/sbt-locales/common-filtering/test
+++ b/sbt-locales/src/sbt-test/sbt-locales/common-filtering/test
@@ -1,3 +1,3 @@
 > managedSources
-$ exec cat jvm/target/scala-2.13/src_managed/main/locales/cldr/data/data.scala
+$ exec cat jvm/target/scala-3.0.0-M2/src_managed/main/locales/cldr/data/data.scala
 > compile

--- a/sbt-locales/src/sbt-test/sbt-locales/no-filtering/build.sbt
+++ b/sbt-locales/src/sbt-test/sbt-locales/no-filtering/build.sbt
@@ -8,7 +8,7 @@ lazy val root =
     .settings(
       name := "no-filtering",
       scalaVersion := "2.13.4",
-      cldrVersion := CLDRVersion.Version("35"),
+      cldrVersion := CLDRVersion.Version("35.0"),
       localesFilter := LocalesFilter.All,
       nsFilter := NumberingSystemFilter.All,
       calendarFilter := CalendarFilter.All,


### PR DESCRIPTION
Makes it work with the new url schema of CLDR. I have to drop support to get the latest, the version of CLDR has to be passed explicitly.