### PR TITLE
Scala 3 RC2, drop M3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -43,8 +43,8 @@ lazy val api = crossProject(JSPlatform, JVMPlatform, NativePlatform)
     name := "cldr-api",
     scalaVersion := "2.12.13", // needs to match the version for sbt
     description := "scala-java-locales cldrl api",
-    crossScalaVersions := Seq("2.13.5", "2.12.13", "2.13.4", "3.0.0-M3", "3.0.0-RC1"),
-    libraryDependencies += "org.scalameta" %%% "munit" % "0.7.22" % Test,
+    crossScalaVersions := Seq("2.13.5", "2.12.13", "2.13.4", "3.0.0-RC1", "3.0.0-RC2"),
+    libraryDependencies += "org.scalameta" %%% "munit" % "0.7.23" % Test,
     testFrameworks += new TestFramework("munit.Framework"),
     libraryDependencies += ("org.portable-scala" %%% "portable-scala-reflect" % "1.1.1")
       .withDottyCompat(scalaVersion.value),


### PR DESCRIPTION
Just traversing the tree back from scala-java-time :)

This PR is adding RC2 and dropping M3 - let me know if it's okay, I think most libraries are maintaining two last Scala 3 versions