### PR TITLE
Split generation of LDML objects to compile on Scala 2.13.4+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ project/metals.sbt
 *.settings/
 /nbproject/private/
 *target/
+.bsp/
 .classpath
 .project
 .checkstyle

--- a/api/src/main/scala/locales/cldr/cldr.scala
+++ b/api/src/main/scala/locales/cldr/cldr.scala
@@ -88,4 +88,6 @@ final case class XMLLDML(
     List(Some(locale.language), locale.script, locale.territory, locale.variant).flatten
       .mkString("_", "_", "")
 
+  val dataScalaSafeName: String = s"${scalaSafeName}_data"
+
 }


### PR DESCRIPTION
scala-java-locales is currently failing to compile on Scala 2.13.4+
since it generates more code compared to Scala 2.13.3 and makes the
compiler fail with MethodTooLarge error.
This creates another set of `private[data] object`s called
`_${languageName}_data` with two defs in them, named
currencies and symbols, so we split the method
in multiple methods, so scala-java-locales compiles just fine in Scala
2.13.4+